### PR TITLE
FEAT(repository): Agregar ruta para relacionar items con unidades

### DIFF
--- a/src/runtime/repository/modules/planificaciones/planificacion.ts
+++ b/src/runtime/repository/modules/planificaciones/planificacion.ts
@@ -95,4 +95,14 @@ export default class PlanificacionModule {
         })
     }
 
+    async relateItemsUnidades(planificacionId: number, unidadId: number, itemEntradaCurricularId: number): Promise<IPlanificacion> {
+        return this.fetcher(`/planificacion/relateUnidadesItems/${planificacionId}`, {
+            method: 'POST',
+            body: {
+                unidadId: unidadId,
+                itemEntradaCurricularId: itemEntradaCurricularId
+            }
+        })
+    }
+
 }


### PR DESCRIPTION
El presente PR introduce cambios para poder llamar la ruta que relaciona los itemsEntradaCurriculares con las unidades de una planificacion