### PR TITLE
11 agregar ruta total componentes curriculares

### DIFF
--- a/src/runtime/models/Planificacion/planificacion.ts
+++ b/src/runtime/models/Planificacion/planificacion.ts
@@ -58,6 +58,6 @@ interface Meta {
     previousPageUrl: string | null
 }
 
-export interface ICantidadComponentes {
+export interface IEstadisticasPlanificacion {
     cantidadComponentes: number
 }

--- a/src/runtime/models/Planificacion/planificacion.ts
+++ b/src/runtime/models/Planificacion/planificacion.ts
@@ -57,3 +57,7 @@ interface Meta {
     nextPageUrl: string | null,
     previousPageUrl: string | null
 }
+
+export interface ICantidadComponentes {
+    cantidadComponentes: number
+}

--- a/src/runtime/repository/modules/planificaciones/planificacion.ts
+++ b/src/runtime/repository/modules/planificaciones/planificacion.ts
@@ -1,6 +1,6 @@
 import type { $Fetch } from 'ofetch';
 import type { IPlanificacion, IPlanificacionForm, IPlanificacionResponse } from '~/src/runtime/models/Planificacion';
-import type { ICantidadComponentes } from '../../../models';
+import type { IEstadisticasPlanificacion } from '../../../models';
 
 
 interface GetAllProps {
@@ -95,8 +95,8 @@ export default class PlanificacionModule {
             }
         })
     }
-    async obtenerTotalComponentesByPlanificacion(planificacionId: number): Promise<ICantidadComponentes> {
-        return this.fetcher(`/planificacion/obtenerTotalComponentes/${planificacionId}`, {
+    async obtenerEstadisticasPlanificacion(planificacionId: number): Promise<IEstadisticasPlanificacion> {
+        return this.fetcher(`/planificacion/obtenerEstadisticasPlanificacion/${planificacionId}`, {
             method: 'GET'
         })
     }

--- a/src/runtime/repository/modules/planificaciones/planificacion.ts
+++ b/src/runtime/repository/modules/planificaciones/planificacion.ts
@@ -94,7 +94,7 @@ export default class PlanificacionModule {
             }
         })
     }
-    async obtenerTotalComponentesByPlanificacion(planificacionId: number): Promise<{ totalComponentes: number }> {
+    async obtenerTotalComponentesByPlanificacion(planificacionId: number): Promise<{ cantidadComponentes: number }> {
         return this.fetcher(`/planificacion/obtenerTotalComponentes/${planificacionId}`, {
             method: 'GET'
         })

--- a/src/runtime/repository/modules/planificaciones/planificacion.ts
+++ b/src/runtime/repository/modules/planificaciones/planificacion.ts
@@ -94,6 +94,10 @@ export default class PlanificacionModule {
             }
         })
     }
+    async obtenerTotalComponentesByPlanificacion(planificacionId: number): Promise<{ totalComponentes: number }> {
+        return this.fetcher(`/planificacion/obtenerTotalComponentes/${planificacionId}`, {
+            method: 'GET'
+        })
+    }
 
-   
 }

--- a/src/runtime/repository/modules/planificaciones/planificacion.ts
+++ b/src/runtime/repository/modules/planificaciones/planificacion.ts
@@ -1,5 +1,6 @@
 import type { $Fetch } from 'ofetch';
 import type { IPlanificacion, IPlanificacionForm, IPlanificacionResponse } from '~/src/runtime/models/Planificacion';
+import type { ICantidadComponentes } from '../../../models';
 
 
 interface GetAllProps {
@@ -94,7 +95,7 @@ export default class PlanificacionModule {
             }
         })
     }
-    async obtenerTotalComponentesByPlanificacion(planificacionId: number): Promise<{ cantidadComponentes: number }> {
+    async obtenerTotalComponentesByPlanificacion(planificacionId: number): Promise<ICantidadComponentes> {
         return this.fetcher(`/planificacion/obtenerTotalComponentes/${planificacionId}`, {
             method: 'GET'
         })


### PR DESCRIPTION
El siguiente PR introduce los cambios necesarios para poder consumir la data de la ruta que devuelve la cantidad de componentes curriculares asociados a una planificacion