### PR TITLE
Filtros planificaciones

### DIFF
--- a/src/runtime/components/ui/toggle/index.ts
+++ b/src/runtime/components/ui/toggle/index.ts
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 export { default as Toggle } from './Toggle.vue'
 
 export const toggleVariants = cva(
-  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground',
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors hover:hover:bg-primary/90 hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground',
   {
     variants: {
       variant: {

--- a/src/runtime/repository/modules/planificaciones/planificacion.ts
+++ b/src/runtime/repository/modules/planificaciones/planificacion.ts
@@ -11,6 +11,8 @@ interface GetAllProps {
     estado?: string;
     colaborativa?: boolean;
     asignatura?: string;
+    nivel?: string;
+    profesor?: string;
     page?: number;
     titulo?: string;
     establecimiento: number;


### PR DESCRIPTION
## Detalles de la PR

- En esta pr se agregan dos atributos al interface de GetAllProps que son las props de los controladores encargados de retornar la lista de las planificaciones.
- Se editan los estilos del elemento Toggle de Shadcn para que por defecto tenga los estilos de colores establecidos como primary.

