### PR TITLE
feat(tooltip) agregar delayduration por defecto en 100

### DIFF
--- a/src/runtime/components/ui/tooltip/Tooltip.vue
+++ b/src/runtime/components/ui/tooltip/Tooltip.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
 import { TooltipRoot, type TooltipRootEmits, type TooltipRootProps, useForwardPropsEmits } from 'reka-ui'
 
-const props = defineProps<TooltipRootProps>()
+const props = withDefaults(defineProps<TooltipRootProps>(), {
+  delayDuration: 100,
+})
 const emits = defineEmits<TooltipRootEmits>()
 
 const forwarded = useForwardPropsEmits(props, emits)
 </script>
 
 <template>
-  <TooltipRoot v-bind="forwarded">
+  <TooltipRoot v-bind="forwarded")>
     <slot />
   </TooltipRoot>
 </template>


### PR DESCRIPTION
Cambios en el codigo 
![image](https://github.com/user-attachments/assets/30085167-0de5-4687-9388-a2f969151976)

Explicacion:
Se agregoó un withDefaults a las props para que si no viene la propiedad delayDuration se establezca con un valor de 100 (valor que hace que la animacion del tooltip sea rapida) y en caso de si venir se aplica el valor que viene en las props