### PR TITLE
feat(planificacion) agregar peticion para obtener descargable de unidad

### DIFF
--- a/src/runtime/models/Planificacion/planificacion.ts
+++ b/src/runtime/models/Planificacion/planificacion.ts
@@ -61,3 +61,8 @@ interface Meta {
 export interface IEstadisticasPlanificacion {
     cantidadComponentes: number
 }
+
+export interface IObtenerDescargableDeUnidad {
+    planificacion: IPlanificacion;
+    unidad: IUnidad
+}

--- a/src/runtime/repository/modules/planificaciones/planificacion.ts
+++ b/src/runtime/repository/modules/planificaciones/planificacion.ts
@@ -1,5 +1,5 @@
 import type { $Fetch } from 'ofetch';
-import type { IPlanificacion, IPlanificacionForm, IPlanificacionResponse } from '~/src/runtime/models/Planificacion';
+import type { IObtenerDescargableDeUnidad, IPlanificacion, IPlanificacionForm, IPlanificacionResponse } from '~/src/runtime/models/Planificacion';
 import type { IEstadisticasPlanificacion } from '../../../models';
 
 
@@ -104,8 +104,15 @@ export default class PlanificacionModule {
             }
         })
     }
+
     async obtenerEstadisticasPlanificacion(planificacionId: number): Promise<IEstadisticasPlanificacion> {
         return this.fetcher(`/planificacion/obtenerEstadisticasPlanificacion/${planificacionId}`, {
+            method: 'GET'
+        })
+    }
+
+    async obtenerDescargableDeUnidad(planificacionId: number, unidadId: number): Promise<IObtenerDescargableDeUnidad> {
+        return this.fetcher(`/planificacion/obtenerDescargableDeUnidad/${planificacionId}/${unidadId}`, {
             method: 'GET'
         })
     }


### PR DESCRIPTION
Esta PR esta relacionada con la PR de la rama 96-generar-descargable-por-unidad en fe-planificacion-next

Codigo
```
 async obtenerDescargableDeUnidad(planificacionId: number, unidadId: number): Promise<IObtenerDescargableDeUnidad> {
        return this.fetcher(`/planificacion/obtenerDescargableDeUnidad/${planificacionId}/${unidadId}`, {
            method: 'GET'
        })
    }
```